### PR TITLE
Fix links barra de navegación

### DIFF
--- a/src/scripts/navigation.ts
+++ b/src/scripts/navigation.ts
@@ -1,4 +1,6 @@
 class Navigation {
+   isLandingPage: boolean;
+
    constructor() {
       document
          .querySelectorAll('.navigation a[href^="/index.html#"]')
@@ -7,6 +9,12 @@ class Navigation {
          });
 
       document.addEventListener('scroll', this.scrolled);
+
+      this.isLandingPage = this.isPageLandingPage();
+
+      if (this.isLandingPage) {
+         document.querySelector('.navigation')?.classList.add('light-text');
+      }
    }
 
    anchorClick(this: HTMLElement, e: any) {
@@ -28,13 +36,26 @@ class Navigation {
       }
    }
 
-   scrolled() {
+   scrolled = () => {
       if (document.documentElement.scrollTop > 50) {
          document.querySelector('.navigation')?.classList.add('scrolling');
+
+         if(this.isLandingPage) {
+            document.querySelector('.navigation')?.classList.remove('light-text');
+         }
       } else {
          document.querySelector('.navigation')?.classList.remove('scrolling');
+
+         if(this.isLandingPage) {
+            document.querySelector('.navigation')?.classList.add('light-text');
+         }
       }
    }
+
+   isPageLandingPage(): boolean {
+      const currentURL = window.location.pathname;
+      return Boolean(currentURL === '/' || currentURL.includes('index.html'));
+    }
 }
 
 new Navigation();

--- a/src/scss/navigation.scss
+++ b/src/scss/navigation.scss
@@ -6,6 +6,10 @@
    padding: 1rem;
    z-index: 10;
 
+   &.light-text #menuToggle #menu li{
+      color: var.$color-light;
+   }
+
    .container {
       padding: 0rem !important;
    }
@@ -100,7 +104,7 @@
          li {
             padding: 10px 0;
             font-size: 1.1rem;
-            color: var.$color-light;
+            color: var.$color-primary;
          }
       }
 
@@ -176,7 +180,7 @@
             transition: all 0s;
 
             li {
-               color: var.$color-light;
+               color: var.$color-primary;
                margin-left: 1.5em;
                padding: 1em 0;
                font-family: 'Gordita Bold';

--- a/src/scss/navigation.scss
+++ b/src/scss/navigation.scss
@@ -6,10 +6,6 @@
    padding: 1rem;
    z-index: 10;
 
-   &.light-text #menuToggle #menu li{
-      color: var.$color-light;
-   }
-
    .container {
       padding: 0rem !important;
    }
@@ -104,7 +100,7 @@
          li {
             padding: 10px 0;
             font-size: 1.1rem;
-            color: var.$color-primary;
+            color: var.$color-light;
          }
       }
 
@@ -141,7 +137,7 @@
 }
 
 @media screen and (min-width: var.$resolution-medium) {
-   .navigation {
+   .navigation {     
       #menuToggle {
          span {
             background: var.$color-light;
@@ -152,6 +148,11 @@
 
 @media screen and (min-width: var.$resolution-large) {
    .navigation {
+      
+      &.light-text #menuToggle #menu li{
+         color: var.$color-light;
+      }
+      
       &.scrolling {
          #menuToggle #menu {
             li {


### PR DESCRIPTION
Se cambió un poco la lógica de los colores en la nav bar, ahora se aplica una clase llamada light-text solo en landing page (desktop)

Para probar el cambio pueden navegar a la pagina de [meetups](http://localhost:8080/meetups.html) y ver el colors de los links
<img width="1382" alt="image" src="https://user-images.githubusercontent.com/5043310/188294984-4360a151-d1f7-47b1-950f-c90cf923c7ad.png">
